### PR TITLE
chore: replace GitHub dependabot reviewers with codeowners (INTERN-68)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# GitHub Actions files
+/.github/               @skriptfabrik/github-actions-maintainers
+
+# Devcontainer configuration
+/.devcontainer/         @skriptfabrik/devcontainer-maintainers
+
+# Docker files
+Dockerfile              @skriptfabrik/docker-maintainers
+
+# NPM package files
+package.json            @skriptfabrik/npm-maintainers
+package-lock.yaml       @skriptfabrik/npm-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,6 @@
 # GitHub Actions files
 /.github/               @skriptfabrik/github-actions-maintainers
 
-# Devcontainer configuration
-/.devcontainer/         @skriptfabrik/devcontainer-maintainers
-
 # Docker files
 Dockerfile              @skriptfabrik/docker-maintainers
 

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,8 +11,6 @@ registries:
 updates:
   - package-ecosystem: 'docker'
     directory: '/'
-    reviewers:
-      - 'skriptfabrik/docker-maintainers'
     registries:
       - 'dockerhub'
     schedule:
@@ -20,8 +18,6 @@ updates:
 
   - package-ecosystem: 'github-actions'
     directory: '/'
-    reviewers:
-      - 'skriptfabrik/github-actions-maintainers'
     schedule:
       interval: 'weekly'
 
@@ -29,7 +25,5 @@ updates:
     directory: '/'
     ignore:
       - dependency-name: '@types/*'
-    reviewers:
-      - 'skriptfabrik/npm-maintainers'
     schedule:
       interval: 'weekly'


### PR DESCRIPTION
This pull request will replace the retiring dependabot reviewers configuration with CODEOWNERS.